### PR TITLE
fix bug in evaluator

### DIFF
--- a/src/yival/evaluators/openai_prompt_based_evaluator.py
+++ b/src/yival/evaluators/openai_prompt_based_evaluator.py
@@ -43,7 +43,7 @@ def extract_choice_from_response(
         if not sanitized_line:
             continue
         for choice in choice_strings:
-            if MATCH_FNS["starts_or_endswith"](sanitized_line, choice):
+            if MATCH_FNS["exact"](sanitized_line, choice):
                 return choice
     return "invalid response"
 


### PR DESCRIPTION
```
def debug():
    input = """
    response_content:Step 1: Evaluate if the headline clearly communicates what the startup does or what problem it solves. The headline "Unlock the Power of Blockchain: The Ultimate Solution for Enhanced Security" does communicate that the startup is involved in blockchain technology and aims to provide enhanced security solutions.
    Step 2: Determine if it is immediately clear to anyone who reads the headline what the startup's purpose is. The headline does make it clear that the startup's purpose is to provide security solutions using blockchain technology.
    Step 3: Assess if there is any lack of clarity that can lead to confusion and may discourage potential users or investors. The headline is straightforward and does not seem to have any elements that could cause confusion.
    Conclusion: The headline meets the criterion very well.

    E
    """
    choice = extract_choice_from_response(input, ["A", "B", "C", "D", "E"])
    print(f"choice is now {choice}")


if __name__ == "__main__":
    debug()

choice is now C
```

fix starts_or_endswith -> exact

The modifications have been run on my config file and no other issues were found.