### PR TITLE
Add support for Palm, Claude-2, Llama2, CodeLlama (100+LLMs)

### DIFF
--- a/demo/auto_prompt_bot.py
+++ b/demo/auto_prompt_bot.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -18,7 +19,7 @@ def reply(input: str) -> str:
         "content": str(StringWrapper("", name="prompt")) + f'\n{input}'
     }]
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
 

--- a/demo/auto_reply/reply.py
+++ b/demo/auto_reply/reply.py
@@ -5,6 +5,7 @@ import uuid
 
 import faiss
 import openai
+from litellm import completion
 from langchain.docstore import InMemoryDocstore
 from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.schema import Document
@@ -140,7 +141,7 @@ class Reply:
         # Create a chat message sequence
         messages = [{"role": "user", "content": message}]
         # Use the chat-based completion
-        response = openai.ChatCompletion.create(
+        response = completion(
             model="gpt-3.5-turbo", messages=messages
         )
 

--- a/demo/essay_topic_outline.py
+++ b/demo/essay_topic_outline.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -24,7 +25,7 @@ def essay_topic_outline(topic: str) -> str:
     }]
 
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
     res = response['choices'][0]['message']['content']

--- a/demo/headline_generation.py
+++ b/demo/headline_generation.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -27,7 +28,7 @@ def headline_generation(tech_startup_business: str) -> str:
         ) + f'{tech_startup_business}'
     }]
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
     res = response['choices'][0]['message']['content']

--- a/demo/logo_generation.py
+++ b/demo/logo_generation.py
@@ -6,6 +6,7 @@ import os
 import time
 
 import openai
+from litellm import completion
 import requests
 from PIL import Image
 from requests.adapters import HTTPAdapter  # type: ignore
@@ -28,7 +29,7 @@ def prompt_generation(prompt: str) -> str:
     '''generate prompt for chatgpt based on the input'''
     openai.api_key = os.getenv("OPENAI_API_KEY")
     messages = [{"role": "user", "content": prompt}]
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo",
         messages=messages,
         temperature=1.0,

--- a/demo/prompts_retrivel/retrivel_variation_generator.py
+++ b/demo/prompts_retrivel/retrivel_variation_generator.py
@@ -2,7 +2,7 @@ import csv
 from typing import Iterator, List
 
 import faiss  # pylint: disable=import-error
-import openai
+from litellm import completion
 from langchain.docstore import InMemoryDocstore
 from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.schema import Document
@@ -122,7 +122,7 @@ class RetrivelVariationGenerator(BaseVariationGenerator):
             f"use case: {self.config.use_case}"  # type: ignore
         })
         if len(documents) == 0:
-            response = openai.ChatCompletion.create(
+            response = completion(
                 model="gpt-4",
                 messages=prompt_generation_message,
                 temperature=0.0
@@ -141,7 +141,7 @@ class RetrivelVariationGenerator(BaseVariationGenerator):
             choices=choices_to_string(choices_strings)
         )
         messages = [{"role": "user", "content": prompt}]
-        response = openai.ChatCompletion.create(
+        response = completion(
             model="gpt-4", messages=messages, temperature=0.0
         )
         response_content = response['choices'][0]['message']['content']
@@ -150,7 +150,7 @@ class RetrivelVariationGenerator(BaseVariationGenerator):
         )
 
         if choice == choices_strings[-1]:
-            response = openai.ChatCompletion.create(
+            response = completion(
                 model="gpt-4-32k",
                 messages=prompt_generation_message,
                 temperature=0.5

--- a/demo/qa.py
+++ b/demo/qa.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -23,7 +24,7 @@ def qa(input: str) -> str:
         "content": f'{input}' + str(StringWrapper("", name="qa"))
     }]
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
 

--- a/demo/translate_to_chinese.py
+++ b/demo/translate_to_chinese.py
@@ -1,6 +1,7 @@
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -29,7 +30,7 @@ def translate_to_chinese(input: str) -> str:
         ) + f'{input}'
     }]
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{ include = "yival", from = "src" }]
 yival = 'yival.__main__:main'
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4"
+python = ">=3.10,<4"
 openai = "^0.27.4"
 hydra-core = "^1.3.2"
 omegaconf = "^2.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{ include = "yival", from = "src" }]
 yival = 'yival.__main__:main'
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4"
+python = ">=3.9,<4"
 openai = "^0.27.4"
 hydra-core = "^1.3.2"
 omegaconf = "^2.3.0"
@@ -39,6 +39,7 @@ pillow = "9.4.0"
 types-requests = "^2.31.0.2"
 types-pillow = "^10.0.0.2"
 dash-dangerously-set-inner-html = "^0.0.2"
+litellm = "^0.1.538"
 
 [tool.poetry.group.doc.dependencies]
 mkdocs = "*"

--- a/src/yival/demo/headline_generation.py
+++ b/src/yival/demo/headline_generation.py
@@ -5,6 +5,7 @@ Demo code for headline generation using GPT-3.
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -40,7 +41,7 @@ def headline_generation(tech_startup_business: str) -> str:
         )
     }]
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
     res = response['choices'][0]['message']['content']

--- a/src/yival/demo/qa.py
+++ b/src/yival/demo/qa.py
@@ -4,6 +4,7 @@ Demo code for question answering using GPT-3.
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -29,7 +30,7 @@ def qa(question: str) -> str:
         "content": f'{question} ' + str(StringWrapper("", name="qa"))
     }]
     # Use the chat-based completion
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages, temperature=0
     )
 

--- a/src/yival/demo/translation.py
+++ b/src/yival/demo/translation.py
@@ -4,6 +4,7 @@ Demo code to translate text from English to Chinese using GPT-3.
 import os
 
 import openai
+from litellm import completion
 
 from yival.logger.token_logger import TokenLogger
 from yival.wrappers.string_wrapper import StringWrapper
@@ -34,7 +35,7 @@ def translate(input: str) -> str:
             )
         ) + f'{input}'
     }]
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-3.5-turbo", messages=messages
     )
 

--- a/src/yival/evaluators/openai_prompt_based_evaluator.py
+++ b/src/yival/evaluators/openai_prompt_based_evaluator.py
@@ -12,6 +12,7 @@ import string
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import openai
+from litellm import completion
 
 from ..schemas.evaluator_config import (
     EvaluatorOutput,
@@ -124,7 +125,7 @@ class OpenAIPromptBasedEvaluator(BaseEvaluator):
         prompt[-1]["content"] += "\n\n" + CLASSIFY_STR.format(
             choices=choices_to_string(self.config.choices)
         )
-        response = openai.ChatCompletion.create(
+        response = completion(
             model="gpt-4", messages=prompt, temperature=0.0
         )
         response_content = response['choices'][0]['message']['content']


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM allows you to use any LLM as a drop in replacement for `gpt-3.5-turbo` 

In addition LiteLLM client allows you to:
* A/B test LLMs in production 
* Dynamically control each LLMs prompt, temperature, top_k etc in our UI (no need to re-deploy code)
* Logging to view input/outputs for each LLM

Here's a link to a live demo of litellm client: https://admin.litellm.ai/ 

![liteLLM-Ab-testing](https://github.com/ConvLab/ConvLab-3/assets/29436595/4206cb62-4c83-4ea1-9be2-e5a7dd306048)
